### PR TITLE
Define $vocabulary for the metaschema

### DIFF
--- a/metaschemas/v1.json
+++ b/metaschemas/v1.json
@@ -1,5 +1,15 @@
 {
   "$id": "https://json-unify.github.io/vocab-dataset/v1.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$vocabulary": {
+    "https://json-schema.org/draft/2020-12/vocab/core": true,
+    "https://json-schema.org/draft/2020-12/vocab/applicator": true,
+    "https://json-schema.org/draft/2020-12/vocab/unevaluated": true,
+    "https://json-schema.org/draft/2020-12/vocab/validation": true,
+    "https://json-schema.org/draft/2020-12/vocab/meta-data": true,
+    "https://json-schema.org/draft/2020-12/vocab/format-annotation": true,
+    "https://json-schema.org/draft/2020-12/vocab/content": true,
+    "https://json-unify.github.io/vocab-dataset": true
+  },
   "title": "A vocabulary for defining datasets using JSON Schema"
 }


### PR DESCRIPTION
Essentially, the meta-schema uses 2020-12 + the dataset vocabulary.

Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
