### PR TITLE
Set core as a required vocabulary

### DIFF
--- a/metaschemas/v1.json
+++ b/metaschemas/v1.json
@@ -3,7 +3,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "A vocabulary for defining datasets using JSON and JSON Schema",
   "$vocabulary": {
-    "https://json-schema.org/draft/2020-12/vocab/core": false,
+    "https://json-schema.org/draft/2020-12/vocab/core": true,
     "https://json-schema.org/draft/2020-12/vocab/applicator": false,
     "https://json-schema.org/draft/2020-12/vocab/unevaluated": false,
     "https://json-schema.org/draft/2020-12/vocab/validation": false,


### PR DESCRIPTION
Core cannot be optional. This is a small issue I picked up during our
call today.

Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
