### PR TITLE
Set vocab/meta-data as required

### DIFF
--- a/metaschemas/v1.json
+++ b/metaschemas/v1.json
@@ -7,7 +7,7 @@
     "https://json-schema.org/draft/2020-12/vocab/applicator": false,
     "https://json-schema.org/draft/2020-12/vocab/unevaluated": false,
     "https://json-schema.org/draft/2020-12/vocab/validation": false,
-    "https://json-schema.org/draft/2020-12/vocab/meta-data": false,
+    "https://json-schema.org/draft/2020-12/vocab/meta-data": true,
     "https://json-schema.org/draft/2020-12/vocab/format-annotation": false,
     "https://json-schema.org/draft/2020-12/vocab/content": false,
     "https://json-unify.github.io/vocab-dataset/v1": true


### PR DESCRIPTION
As dataset metadata is actually required?

Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
